### PR TITLE
feat(stock): Gérer le facteur de perte pour la consommation d'ouvrages

### DIFF
--- a/app/Http/Requests/Articles/OuvrageCompositionRequest.php
+++ b/app/Http/Requests/Articles/OuvrageCompositionRequest.php
@@ -11,6 +11,7 @@ class OuvrageCompositionRequest extends FormRequest
         return [
             'article_id' => ['required', 'exists:articles,id'],
             'quantity_needed' => ['required', 'numeric', 'gt:0'],
+            'wastage_factor_pct' => ['nullable', 'numeric', 'min:0', 'max:100'],
         ];
     }
 

--- a/app/Http/Requests/Articles/OuvrageConsumptionRequest.php
+++ b/app/Http/Requests/Articles/OuvrageConsumptionRequest.php
@@ -15,6 +15,7 @@ class OuvrageConsumptionRequest extends FormRequest
             'project_id' => ['required', 'exists:projects,id'],
             'project_phase_id' => ['nullable', 'exists:project_phases,id'],
             'reference' => ['nullable', 'string', 'max:100'],
+            'wastage_factor_pct' => ['nullable', 'numeric', 'min:0', 'max:100'],
         ];
     }
 

--- a/app/Models/Articles/Ouvrage.php
+++ b/app/Models/Articles/Ouvrage.php
@@ -38,12 +38,19 @@ class Ouvrage extends Model
     }
 
     /**
-     * Coût de revient théorique de l'ouvrage.
-     * Basé sur le Coût Unitaire Moyen Pondéré (CUMP) actuel des articles composants.
+     * COÛT THÉORIQUE "PRUDENT"
+     * Calcule le coût en incluant les pertes et chutes définies dans la nomenclature.
      */
-    public function getTheoreticalCostAttribute(): float {
+    public function getTheoreticalCostAttribute(): float
+    {
         return (float) $this->components->sum(function($article) {
-            return (float) $article->pivot->quantity_needed * (float) $article->cump_ht;
+            $qty = (float) $article->pivot->quantity_needed;
+            $wastage = (float) ($article->pivot->wastage_factor_pct ?? 0);
+
+            // On valorise la quantité qui sera réellement déstockée
+            $realQty = $qty * (1 + ($wastage / 100));
+
+            return $realQty * (float) $article->cump_ht;
         });
     }
 }

--- a/database/migrations/2026_02_01_003042_create_ouvrage_articles_table.php
+++ b/database/migrations/2026_02_01_003042_create_ouvrage_articles_table.php
@@ -15,6 +15,7 @@ return new class extends Migration {
             $table->foreignIdFor(Article::class)->constrained()->cascadeOnDelete();
 
             $table->decimal('quantity_needed', 15, 4);
+            $table->decimal('wastage_factor_pct', 5, 2)->default(5);
 
             $table->timestamps();
 


### PR DESCRIPTION
Cette fonctionnalité introduit la gestion du facteur de perte (ou chute) pour les articles composants d'un ouvrage. Ce facteur permet de définir un pourcentage de surconsommation lors du déstockage des composants.

Les modifications incluent :
- Ajout du champ `wastage_factor_pct` dans la table pivot `ouvrage_articles` pour définir une perte par composant.
- Mise à jour des requêtes de validation pour `OuvrageCompositionRequest` et `OuvrageConsumptionRequest` afin de supporter ce nouveau facteur.
- Ajustement du calcul des quantités déstockées dans `StockMovementService::recordOuvrageExit` pour inclure le facteur de perte (priorité : surdéfinition globale > facteur du composant).
- Mise à jour du calcul du coût théorique d'un ouvrage pour intégrer ces pertes, reflétant un coût plus réaliste.

Cela assure une meilleure précision dans la gestion des stocks et la valorisation des ouvrages.