### PR TITLE
feat(commerce): Historiser les réceptions de commandes

### DIFF
--- a/app/Models/Commerce/PurchaseOrderReception.php
+++ b/app/Models/Commerce/PurchaseOrderReception.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models\Commerce;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PurchaseOrderReception extends Model
+{
+    use HasFactory;
+    protected $guarded = [];
+
+    public function item(): BelongsTo
+    {
+        return $this->belongsTo(PurchaseOrderItem::class);
+    }
+
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'received_at' => 'date',
+            'quantity' => 'decimal:3',
+        ];
+    }
+}

--- a/app/Services/Commerce/PurchaseOrderService.php
+++ b/app/Services/Commerce/PurchaseOrderService.php
@@ -6,9 +6,11 @@ use App\Enums\Commerce\PurchaseOrderStatus;
 use App\Models\Articles\Warehouse;
 use App\Models\Commerce\PurchaseOrder;
 use App\Models\Commerce\PurchaseOrderItem;
+use App\Models\Commerce\PurchaseOrderReception;
 use App\Services\Articles\StockMovementService;
 use DB;
 use Exception;
+use Illuminate\Support\Facades\Auth;
 
 class PurchaseOrderService
 {
@@ -26,12 +28,11 @@ class PurchaseOrderService
     }
 
     /**
-     * Enregistre une réception de marchandise liée à un bon de commande.
-     * Met à jour les reliquats et déclenche les entrées en stock.
+     * Enregistre une réception de marchandise avec historique complet.
      */
-    public function recordReception(PurchaseOrder $order, Warehouse $warehouse, array $itemsData): void
+    public function recordReception(PurchaseOrder $order, Warehouse $warehouse, array $itemsData, string $deliveryNoteRef, ?string $receivedAt = null): void
     {
-        DB::transaction(function () use ($order, $warehouse, $itemsData) {
+        DB::transaction(function () use ($order, $warehouse, $itemsData, $deliveryNoteRef, $receivedAt) {
             foreach ($itemsData as $data) {
                 $item = PurchaseOrderItem::findOrFail($data['item_id']);
                 $qtyReceived = (float) $data['quantity'];
@@ -40,17 +41,29 @@ class PurchaseOrderService
                     continue;
                 }
 
-                // Mise à jour du reliquat sur la ligne de commande
+                // 1. ARCHIVAGE : Enregistrement dans l'historique des réceptions (Audit Trail)
+                PurchaseOrderReception::create([
+                    'purchase_order_item_id' => $item->id,
+                    'quantity' => $qtyReceived,
+                    'delivery_note_ref' => $deliveryNoteRef,
+                    'received_at' => $receivedAt ?? now()->format('Y-m-d'),
+                    'created_by' => Auth::id(),
+                ]);
+
+                // 2. DENORMALISATION : Mise à jour du total reçu sur la ligne pour la performance
                 $item->increment('received_quantity', $qtyReceived);
 
-                // Déclenchement de l'entrée en stock réelle via le module Inventaire
+                // 3. LOGISTIQUE : Entrée en stock réelle
                 if ($item->article) {
                     $this->stockService->recordEntry(
                         $item->article,
                         $warehouse,
                         $qtyReceived,
                         (float) $item->unit_price_ht,
-                        ['reference' => $order->reference]
+                        [
+                            'reference' => $deliveryNoteRef, // On trace le BL dans le stock
+                            'notes' => "Réception Commande {$order->reference}",
+                        ]
                     );
                 }
             }
@@ -65,14 +78,14 @@ class PurchaseOrderService
     protected function updateOrderStatusAfterReception(PurchaseOrder $order): void
     {
         $order->load('items');
-
         $totalOrdered = $order->items->sum('quantity');
         $totalReceived = $order->items->sum('received_quantity');
 
+        $status = PurchaseOrderStatus::PartiallyReceived;
         if ($totalReceived >= $totalOrdered) {
-            $order->update(['status' => PurchaseOrderStatus::Received]);
-        } elseif ($totalReceived > 0) {
-            $order->update(['status' => PurchaseOrderStatus::PartiallyReceived]);
+            $status = PurchaseOrderStatus::Received;
         }
+
+        $order->update(['status' => $status]);
     }
 }

--- a/database/factories/Commerce/PurchaseOrderReceptionFactory.php
+++ b/database/factories/Commerce/PurchaseOrderReceptionFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories\Commerce;
+
+use App\Models\Commerce\PurchaseOrderItem;
+use App\Models\Commerce\PurchaseOrderReception;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Carbon;
+
+class PurchaseOrderReceptionFactory extends Factory
+{
+    protected $model = PurchaseOrderReception::class;
+
+    public function definition(): array
+    {
+        return [
+            'quantity' => $this->faker->randomFloat(),
+            'delivery_note_ref' => $this->faker->word(),
+            'received_at' => Carbon::now(),
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+
+            'purchase_order_item_id' => PurchaseOrderItem::factory(),
+            'created_by' => User::factory(),
+        ];
+    }
+}

--- a/database/migrations/2026_02_04_132539_create_purchase_order_receptions_table.php
+++ b/database/migrations/2026_02_04_132539_create_purchase_order_receptions_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Models\Commerce\PurchaseOrderItem;
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('purchase_order_receptions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(PurchaseOrderItem::class)->constrained()->cascadeOnDelete();
+            $table->decimal('quantity', 15, 3);
+            $table->string('delivery_note_ref')->nullable()->comment('Référence du BL Fournisseur');
+            $table->date('received_at');
+            $table->foreignIdFor(User::class, 'created_by')->constrained();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('purchase_order_receptions');
+    }
+};


### PR DESCRIPTION
Introduction du modèle PurchaseOrderReception pour un suivi détaillé des réceptions de commandes. Chaque réception d'article est désormais archivée avec sa quantité, la référence du bon de livraison et l'utilisateur responsable.

La méthode PurchaseOrderService::recordReception a été mise à jour pour enregistrer ces informations et inclure la référence du BL dans le mouvement de stock.

Ajout des migrations et usines (factories) associées.