### PR TITLE
fix(database): Corriger la définition de la table article_serial_numbers

### DIFF
--- a/database/migrations/2026_01_31_214211_create_article_serial_numbers_table.php
+++ b/database/migrations/2026_01_31_214211_create_article_serial_numbers_table.php
@@ -13,7 +13,7 @@ return new class extends Migration {
     {
         Schema::create('article_serial_numbers', function (Blueprint $table) {
             $table->id();
-            $table->foreignIdFor(\App\Models\Core\Tenants::class)->constrained()->cascadeOnDelete();
+            $table->foreignIdFor(\App\Models\Core\Tenants::class, 'tenants_id')->constrained()->cascadeOnDelete();
             $table->foreignIdFor(Article::class)->constrained()->cascadeOnDelete();
             $table->foreignIdFor(Warehouse::class)->nullable()->constrained()->nullOnDelete();
 
@@ -28,7 +28,10 @@ return new class extends Migration {
             $table->date('warranty_expiry')->nullable();
             $table->timestamps();
 
-            $table->unique(['article_id', 'serial_number', 'tenants_id']);
+            $table->unique(
+                ['article_id', 'serial_number', 'tenants_id'],
+                'art_sn_tenant_unique'
+            );
         });
 
         Schema::table('stock_movements', function (Blueprint $table) {


### PR DESCRIPTION
- Spécifie explicitement le nom de la colonne `tenants_id` pour la relation avec le modèle `Tenants`.
- Ajoute un nom personnalisé (`art_sn_tenant_unique`) à la contrainte d'unicité composite pour éviter les erreurs de longueur d'identifiant.